### PR TITLE
sscma-node: release v0.0.7

### DIFF
--- a/solutions/sscma-node/CMakeLists.txt
+++ b/solutions/sscma-node/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(
     sscma-node
-    VERSION 0.0.6
+    VERSION 0.0.7
     LANGUAGES C CXX
 )
 

--- a/solutions/sscma-node/main/main.cpp
+++ b/solutions/sscma-node/main/main.cpp
@@ -41,9 +41,9 @@ int main(int argc, char** argv) {
     Signal::install({SIGINT, SIGSEGV, SIGABRT, SIGTRAP, SIGTERM, SIGHUP, SIGQUIT, SIGPIPE}, [](int sig) {
         MA_LOGE(TAG, "received signal %d", sig);
         if (sig == SIGSEGV) {
-            NodeFactory::clear();
-        } else {
             deinitVideo();
+        } else {
+            NodeFactory::clear();
         }
         closelog();
         exit(1);

--- a/solutions/sscma-node/main/main.cpp
+++ b/solutions/sscma-node/main/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 
     openlog("sscma", LOG_CONS | LOG_PERROR, LOG_DAEMON);
 
-    MA_LOGD("main", "version: %s", PROJECT_VERSION);
+    MA_LOGD("main", "version: %s build: %s", PROJECT_VERSION, __DATE__ " " __TIME__);
 
     Signal::install({SIGINT, SIGSEGV, SIGABRT, SIGTRAP, SIGTERM, SIGHUP, SIGQUIT, SIGPIPE}, [](int sig) {
         MA_LOGE(TAG, "received signal %d", sig);
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
         config->init(config_file.c_str());
 
         MA_LOGI(TAG, "starting the service...");
-        MA_LOGI(TAG, "version: %s", PROJECT_VERSION);
+        MA_LOGI(TAG, "version: %s build: %s", PROJECT_VERSION, __DATE__ " " __TIME__);
         MA_LOGI(TAG, "config: %s", config_file.c_str());
 
         std::string client;

--- a/solutions/sscma-node/main/node/camera.h
+++ b/solutions/sscma-node/main/node/camera.h
@@ -22,7 +22,7 @@ typedef struct {
 
 class videoFrame {
 public:
-    videoFrame() {
+    videoFrame() : ref_cnt(0) {
         memset(&img, 0, sizeof(ma_img_t));
     }
     ~videoFrame() = default;

--- a/solutions/sscma-node/main/node/node.cpp
+++ b/solutions/sscma-node/main/node/node.cpp
@@ -166,13 +166,13 @@ Node* NodeFactory::create(const std::string id, const std::string type, const js
 void NodeFactory::destroy(const std::string id) {
     Guard guard(m_mutex);
 
-    MA_LOGD(TAG, "destroy node: %s", id.c_str());
-
     // find node
     auto node = m_nodes.find(id);
     if (node == m_nodes.end()) {
         return;
     }
+
+    MA_LOGI(TAG, "destroy node: %s(%s)", id.c_str(), m_nodes[id]->type_.c_str());
 
     for (auto& dep : node->second->dependents_) {
         if (find(dep.first)) {
@@ -210,7 +210,6 @@ void NodeFactory::clear() {
     MA_LOGI(TAG, "clear nodes");
     Guard guard(m_mutex);
     for (auto node : m_nodes) {
-        MA_LOGI(TAG, "destroy node: %s(%s)", node.first.c_str(), node.second->type_.c_str());
         destroy(node.first);
     }
     m_nodes.clear();

--- a/solutions/sscma-node/main/node/save.h
+++ b/solutions/sscma-node/main/node/save.h
@@ -35,7 +35,9 @@ protected:
 
 private:
     std::string generateFileName();
-    bool recycle(std::string filename, uint64_t size);
+    bool recycle(uint32_t req_size = 0);
+    bool openFile(videoFrame* frame);
+    void closeFile();
 
 protected:
     std::string storage_;

--- a/solutions/sscma-node/main/node/save.h
+++ b/solutions/sscma-node/main/node/save.h
@@ -41,8 +41,6 @@ private:
 
 protected:
     std::string storage_;
-    uint64_t max_size_;
-    uint64_t cur_size_;
     int slice_;
     int duration_;
     bool enabled_;


### PR DESCRIPTION
This PR addresses several key improvements and bug fixes related to node handling and video stream management:

1. **Fix YOLOv8 Output Coordinates (Commit: `fix: resolve wrong coordinates issue in YOLOv8 output`)**  
   - Resolved an issue where YOLOv8 was outputting incorrect coordinates, improving the accuracy of detection results.

2. **Fix Video Stream Duration (Commit: `fix: fix issue with saved video stream being half the expected duration`)**  
   - Fixed a bug where saved video streams were only half the expected duration, ensuring correct video length in outputs.

3. **Fix Node Stopping Issue (Commit: `fix: resolve intermittent issue with stopping nodes`)**  
   - Addressed a rare issue where some nodes could not be stopped properly, improving the overall stability of node operations.

These changes aim to improve the reliability and performance of both video stream handling and node lifecycle management, particularly in scenarios involving object detection and node coordination.

**Testing:**

- Tested YOLOv8 object detection with various input videos to ensure correct bounding box outputs.
- Validated saved video stream lengths with different configurations to ensure the expected duration.
- Simulated node start/stop sequences multiple times to ensure stable behavior without failures.